### PR TITLE
Show settings related to Parallel Queries

### DIFF
--- a/lib/pghero/methods/settings.rb
+++ b/lib/pghero/methods/settings.rb
@@ -7,7 +7,7 @@ module PgHero
             %i(
               max_connections shared_buffers effective_cache_size work_mem
               maintenance_work_mem min_wal_size max_wal_size checkpoint_completion_target
-              wal_buffers default_statistics_target
+              wal_buffers default_statistics_target max_worker_processes max_parallel_workers_per_gather max_parallel_workers parallel_tuple_cost parallel_setup_cost min_parallel_table_scan_size min_parallel_index_scan_size max_parallel_maintenance_workers
             )
           else
             %i(


### PR DESCRIPTION
👋 

https://www.postgresql.org/docs/current/runtime-config-resource.html
https://www.postgresql.org/docs/current/how-parallel-query-works.html

Show these settings on tune page.

Their default values as PostgreSQL 12.3:

```sql
psql (12.3)
Type "help" for help.

juanitofatas_development=# SHOW max_worker_processes;
 max_worker_processes
----------------------
 8

juanitofatas_development=# SHOW max_parallel_workers_per_gather;
 max_parallel_workers_per_gather
---------------------------------
 2

juanitofatas_development=# SHOW max_parallel_workers;
 max_parallel_workers
----------------------
 8

juanitofatas_development=# SHOW parallel_tuple_cost;
 parallel_tuple_cost
---------------------
 0.1

juanitofatas_development=# SHOW parallel_setup_cost;
 parallel_setup_cost
---------------------
 1000

juanitofatas_development=# SHOW min_parallel_table_scan_size;
 min_parallel_table_scan_size
------------------------------
 8MB

juanitofatas_development=# SHOW min_parallel_index_scan_size;
 min_parallel_index_scan_size
------------------------------
 512kB

juanitofatas_development=# SHOW max_parallel_maintenance_workers;
 max_parallel_maintenance_workers
----------------------------------
 2

```