### PR TITLE
Live Queries links to PostgreSQL docs use v13, was v12.

### DIFF
--- a/app/views/pg_hero/home/_live_queries_table.html.erb
+++ b/app/views/pg_hero/home/_live_queries_table.html.erb
@@ -27,7 +27,7 @@
                   <%= " (#{progress[:index_vacuum_count] + 1})" %>
                 <% end %>
               </strong>
-              <a href="https://www.postgresql.org/docs/12/progress-reporting.html#VACUUM-PROGRESS-REPORTING" target="_blank">(?)</a>
+              <a href="https://www.postgresql.org/docs/13/progress-reporting.html#VACUUM-PROGRESS-REPORTING" target="_blank">(?)</a>
             </div>
             <% case progress[:phase] %>
             <% when "scanning heap",
@@ -53,7 +53,7 @@
           <% elsif progress = create_index_progress[query[:pid]] %>
             <div>
               <strong><%= progress[:phase] %></strong>
-              <a href="https://www.postgresql.org/docs/12/progress-reporting.html#CREATE-INDEX-PROGRESS-REPORTING" target="_blank">(?)</a>
+              <a href="https://www.postgresql.org/docs/13/progress-reporting.html#CREATE-INDEX-PROGRESS-REPORTING" target="_blank">(?)</a>
             </div>
             <% case progress[:phase] %>
             <% when "initializing",


### PR DESCRIPTION
I noticed the super-helpful links to documentation were pointing at PostgreSQL docs for version 12, but we're (mostly) using version 13. So, this pull request updates the links.
