### PR TITLE
Maintenance info calculates Vacuum Threshold per table

### DIFF
--- a/app/controllers/pg_hero/home_controller.rb
+++ b/app/controllers/pg_hero/home_controller.rb
@@ -387,6 +387,7 @@ module PgHero
       @maintenance_info = @database.maintenance_info
       @time_zone = PgHero.time_zone
       @show_dead_rows = params[:dead_rows]
+      @max_dead_tuples = @database.autovacuum_max_dead_tuples
     end
 
     def kill

--- a/app/views/pg_hero/home/maintenance.html.erb
+++ b/app/views/pg_hero/home/maintenance.html.erb
@@ -7,6 +7,7 @@
         <th>Table</th>
         <th class="text-right">Live Tuples</th>
         <th class="text-right">Dead Tuples</th>
+        <th class="text-right">Vacuum Threshold</th>
         <th class="text-right">Last Vacuum</th>
         <th class="text-right">Last Analyze</th>
         <% if @show_dead_rows %>
@@ -24,7 +25,7 @@
             <% end %>
             <% if table[:options] %>
               <ul style="font-size: 12px" class="text-muted">
-                <% table[:options].gsub(/\A\{|\}\z/, "").split(",").each do |option| %>
+                <% table[:options].each do |option| %>
                   <li><code><%= option %></code></li>
                 <% end %>
               </ul>
@@ -42,6 +43,21 @@
               <span class="text-warning"><%= number_with_delimiter(table[:dead_rows]) %></span>
             <% else %>
               <span class="text-muted">0</span>
+            <% end %>
+          </td>
+          <td class="text-right">
+            <% if table[:vacuum_threshold] > @max_dead_tuples %>
+              <span class="text-warning" title="<%= table[:vacuum_threshold_calc] %>">
+                <%= number_with_delimiter(table[:vacuum_threshold]) %>
+                <br>
+                <span style="font-size: 12px" class="text-muted">
+                  <code>&gt; max_dead_tuples=<%= number_with_delimiter(@max_dead_tuples) %></code>
+                </span>
+              </span>
+            <% else %>
+              <span title="<%= table[:vacuum_threshold_calc] %>">
+                <%= number_with_delimiter(table[:vacuum_threshold]) %>
+              </span>
             <% end %>
           </td>
           <td class="text-right">

--- a/lib/pghero/methods/basic.rb
+++ b/lib/pghero/methods/basic.rb
@@ -41,12 +41,17 @@ module PgHero
         # squish for logs
         retries = 0
         begin
-          result = conn.select_all(add_source(squish(sql)))
-          result = result.cast_values.map { |row| result.columns.zip(row).to_h } if cast_values
+          result = uncast_result = conn.select_all(add_source(squish(sql)))
+          if cast_values
+            # ActiveRecord::Result#cast_values turns PostgreSQL arrays into Ruby arrays, etc.
+            # But it turns ActiveRecord::Result into Array of results, which is why we keep
+            # an `uncast_result` copy of `result`.
+            result = result.cast_values.map { |row| result.columns.zip(row).to_h }
+          end
           if ActiveRecord::VERSION::STRING.to_f >= 6.1
             result = result.map(&:symbolize_keys)
           else
-            result = result.map { |row| row.to_h { |col, val| [col.to_sym, result.column_types[col].send(:cast_value, val)] } }
+            result = result.map { |row| row.to_h { |col, val| [col.to_sym, uncast_result.column_types[col].send(:cast_value, val)] } }
           end
           if filter_data
             query_columns.each do |column|

--- a/lib/pghero/methods/basic.rb
+++ b/lib/pghero/methods/basic.rb
@@ -36,12 +36,13 @@ module PgHero
 
       private
 
-      def select_all(sql, conn: nil, query_columns: [])
+      def select_all(sql, conn: nil, query_columns: [], cast_values: false)
         conn ||= connection
         # squish for logs
         retries = 0
         begin
           result = conn.select_all(add_source(squish(sql)))
+          result = result.cast_values.map { |row| result.columns.zip(row).to_h } if cast_values
           if ActiveRecord::VERSION::STRING.to_f >= 6.1
             result = result.map(&:symbolize_keys)
           else

--- a/lib/pghero/methods/maintenance.rb
+++ b/lib/pghero/methods/maintenance.rb
@@ -88,7 +88,7 @@ module PgHero
       end
 
       def maintenance_info
-        select_all <<~SQL
+        info = select_all(<<~SQL, cast_values: true)
           SELECT
             schemaname AS schema,
             pg_stat_user_tables.relname AS table,
@@ -106,6 +106,26 @@ module PgHero
           ORDER BY
             1, 2
         SQL
+
+        runtime_parameters = autovacuum_settings
+
+        info.each do |row|
+          table_options = row[:options]&.map { |opt| opt.split("=", 2) }.to_h || {}
+
+          # look up a table storage parameter, defaulting to the globally set value
+          find_param = ->(key) { table_options[key.to_s] || runtime_parameters[key] }
+
+          # vacuum_threshold = autovacuum_vacuum_threshold + autovacuum_vacuum_scale_factor * pg_class.reltuples
+          # — https://www.postgresql.org/docs/13/routine-vacuuming.html#AUTOVACUUM
+          threshold = find_param.(:autovacuum_vacuum_threshold).to_i
+          scale_factor = find_param.(:autovacuum_vacuum_scale_factor).to_f
+          reltuples = row[:live_rows].to_i
+
+          row[:vacuum_threshold] = (threshold + scale_factor * reltuples).to_i
+          row[:vacuum_threshold_calc] = "#{threshold} + #{scale_factor} * #{reltuples}"
+        end
+
+        info
       end
 
       def analyze(table, verbose: false)

--- a/lib/pghero/methods/settings.rb
+++ b/lib/pghero/methods/settings.rb
@@ -20,11 +20,40 @@ module PgHero
       end
 
       def autovacuum_settings
-        fetch_settings %i(autovacuum autovacuum_max_workers autovacuum_vacuum_cost_limit autovacuum_vacuum_scale_factor autovacuum_analyze_scale_factor)
+        fetch_settings %i(autovacuum autovacuum_max_workers autovacuum_vacuum_cost_limit autovacuum_vacuum_scale_factor autovacuum_vacuum_threshold autovacuum_analyze_scale_factor)
       end
 
       def vacuum_settings
         fetch_settings %i(vacuum_cost_limit)
+      end
+
+      # The number of dead tuples that an autovacuum phase can track.
+      # https://www.postgresql.org/docs/current/runtime-config-resource.html#GUC-MAINTENANCE-WORK-MEM
+      def autovacuum_max_dead_tuples
+        # SHOW … returns the value as a string like "64MB" which would require parsing the units.
+        # PostgreSQL stores this as kB (KiB) internally, which is simpler / less ambiguous.
+        show_setting_kb = ->(key) {
+          select_one("SELECT setting FROM pg_settings WHERE name = '#{key}' AND unit = 'kB'")
+        }
+
+        # autovacuum_work_mem (integer):
+        # Specifies the maximum amount of memory to be used by each autovacuum worker process.
+        work_mem_kib = show_setting_kb.(:autovacuum_work_mem).to_i
+
+        # It defaults to -1, indicating that maintenance_work_mem should be used instead.
+        if work_mem_kib == -1
+          work_mem_kib = show_setting_kb.(:maintenance_work_mem).to_i
+        end
+
+        # For the collection of dead tuple identifiers, VACUUM is only able to utilize up to a
+        # maximum of 1GB of memory.
+        work_mem = [work_mem_kib * 1024, 1024*1024*1024].min
+
+        # I can't remember why this is 6 bytes, but it is.
+        bytes_per_tuple_ref = 6
+
+        # This maxes out at 178,956,969 for work_mem >= 1 GiB
+        (work_mem / bytes_per_tuple_ref) - 1
       end
 
       private


### PR DESCRIPTION
Each table on the Maintenance page shows a calculated “vacuum threshold”, as described in [PostgreSQL manual 25.1.6. Routine Vacuuming — The Autovacuum Daemon](https://www.postgresql.org/docs/current/routine-vacuuming.html#AUTOVACUUM):

> Tables whose relfrozenxid value is more than [autovacuum_freeze_max_age](https://www.postgresql.org/docs/current/runtime-config-autovacuum.html#GUC-AUTOVACUUM-FREEZE-MAX-AGE) transactions old are always vacuumed (this also applies to those tables whose freeze max age has been modified via storage parameters; see below). Otherwise, if the number of tuples obsoleted since the last VACUUM exceeds the “vacuum threshold”, the table is vacuumed. The vacuum threshold is defined as:
> 
> ```
> vacuum threshold = vacuum base threshold + vacuum scale factor * number of tuples
> ```
> 
> where the vacuum base threshold is [autovacuum_vacuum_threshold](https://www.postgresql.org/docs/current/runtime-config-autovacuum.html#GUC-AUTOVACUUM-VACUUM-THRESHOLD), the vacuum scale factor is [autovacuum_vacuum_scale_factor](https://www.postgresql.org/docs/current/runtime-config-autovacuum.html#GUC-AUTOVACUUM-VACUUM-SCALE-FACTOR), and the number of tuples is pg_class.reltuples.

The new column shows the value calculated from either the table's parameters or the system-wide parameter, and shows a warning if the value exceeds the calculated `max_dead_tuples`, described in [PostgreSQL manual 28.4.3. Progress Reporting — VACUUM Progress Reporting](https://www.postgresql.org/docs/current/progress-reporting.html#VACUUM-PROGRESS-REPORTING):

> max_dead_tuples bigint
> 
> Number of dead tuples that we can store before needing to perform an index vacuum cycle, based on [maintenance_work_mem](https://www.postgresql.org/docs/current/runtime-config-resource.html#GUC-MAINTENANCE-WORK-MEM).

The warning is shown because when the calculated vacuum threshold exceeds the calculated `max_dead_tuples`, the resulting autovacuum will have to run multiple passes/phases, which incurs a lot of overhead on large tables, and in extreme cases can contribute to risk of transaction ID wraparound.

Here's a preview of it in action:

![image](https://github.com/buildkite/pghero/assets/15759/8e43adaa-183f-4821-bfa2-38b99dbd9ba5)

Note the hovering tooltip is the title attribute showing how the value was derived.