### PR TITLE
Make database selector fixed height

### DIFF
--- a/app/assets/stylesheets/pghero/application.css
+++ b/app/assets/stylesheets/pghero/application.css
@@ -251,6 +251,8 @@ hr {
   border-radius: 2px;
   box-shadow: rgba(0, 0, 0, 0.298039) 0px 4px 10px 0px, rgba(0, 0, 0, 0.027451) 0px 0px 0px 1px;
   width: 200px;
+  height: 800px;
+  overflow-y: scroll;
 }
 
 .db-switcher .popup li a {


### PR DESCRIPTION
Currently if the database list in the selector extends beyond the page fold it's not possible to scroll and the only way to select a database below the fold is to zoom out of the page until the required database is visible.

This is a fairly hacky solution which makes the selector a fixed height and adds scroll.  Open to other solutions.