### PR TITLE
Add VERBOSE and BUFFERS to explain analyze

### DIFF
--- a/app/controllers/pg_hero/home_controller.rb
+++ b/app/controllers/pg_hero/home_controller.rb
@@ -298,7 +298,7 @@ module PgHero
           explain_options =
             case params[:commit]
             when "Analyze"
-              {analyze: true}
+              {analyze: true, verbose: true, buffers: true}
             when "Visualize"
               if @explain_analyze_enabled
                 {analyze: true, costs: true, verbose: true, buffers: true, format: "json"}


### PR DESCRIPTION
`BUFFERS` is probably the single most useful metric when assessing query plans, see [rationale here](https://postgres.ai/blog/20220106-explain-analyze-needs-buffers-to-improve-the-postgres-query-optimization-process).

This adds `BUFFERS` (and `VERBOSE` for good measure) to the `Analyze` output from pghero.  Note these options are already added when the `Visualize` button is used but the resulting output is JSON rather than the (slightly) more human readable output from `Analyze`.