### PR TITLE
Embed PEV2 plan viewer into Explain -> Visualize

### DIFF
--- a/app/views/pg_hero/home/_pev2.html.erb
+++ b/app/views/pg_hero/home/_pev2.html.erb
@@ -6,7 +6,7 @@
 />
 <link rel="stylesheet" href="https://unpkg.com/pev2/dist/style.css" />
 
-<div id="pev2">
+<div id="pev2" class="d-flex flex-column" style="height: 50vh">
   <pev2 :plan-source="plan" plan-query="" />
 </div>
 

--- a/app/views/pg_hero/home/_pev2.html.erb
+++ b/app/views/pg_hero/home/_pev2.html.erb
@@ -1,0 +1,27 @@
+<script src="https://unpkg.com/vue@3.2.45/dist/vue.global.prod.js"></script>
+<script src="https://unpkg.com/pev2/dist/pev2.umd.js"></script>
+<link
+  href="https://unpkg.com/bootstrap@5.3.2/dist/css/bootstrap.min.css"
+  rel="stylesheet"
+/>
+<link rel="stylesheet" href="https://unpkg.com/pev2/dist/style.css" />
+
+<div id="pev2">
+  <pev2 :plan-source="plan" plan-query="" />
+</div>
+
+<script>
+  const { createApp } = Vue;
+
+  const plan = "<%= escape_javascript(plan.html_safe) %>";
+
+  const app = createApp({
+    data() {
+      return {
+        plan: plan,
+      }
+    },
+  });
+  app.component("pev2", pev2.Plan);
+  app.mount("#pev2");
+</script>

--- a/app/views/pg_hero/home/explain.html.erb
+++ b/app/views/pg_hero/home/explain.html.erb
@@ -14,9 +14,17 @@
 
   <% if @explanation %>
     <% if @visualize %>
-      <p>Paste the output below into the <%= link_to "explain visualizer", PgHero.visualize_url, target: "_blank" %></p>
+      <hr>
+      <%= render partial: "pev2", locals: { plan: @explanation } %>
+      <hr>
+      <details>
+        <summary>PEV version 1 instructions</summary>
+        <p>Paste the output below into the <%= link_to "explain visualizer", PgHero.visualize_url, target: "_blank" %></p>
+        <pre><code><%= @explanation %></code></pre>
+      </details>
+    <% else %>
+      <pre><code><%= @explanation %></code></pre>
     <% end %>
-    <pre><code><%= @explanation %></code></pre>
     <% unless @visualize %>
       <p><%= link_to "See how to interpret this", "https://www.postgresql.org/docs/current/static/using-explain.html", target: "_blank" %></p>
     <% end %>


### PR DESCRIPTION
Embeds the PEV2 plan viewer into the _Explain -> Visualize_ page.

![image](https://github.com/user-attachments/assets/37f434ed-6ef0-476f-a5f5-d8b822fe7af3)

The previous instructions with a link to PEV version 1 are still below the new viewer in a collapsed `<summary>` block.
