### PR TITLE
Upstream v3.3.4 merged into Buildkite fork 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,10 @@ jobs:
         include:
           - ruby: 3.2
             gemfile: gemfiles/activerecord71.gemfile
-            postgres: 15
+            postgres: 16
           - ruby: 3.1
             gemfile: Gemfile
-            postgres: 14
+            postgres: 15
           - ruby: "3.0"
             gemfile: gemfiles/activerecord61.gemfile
             postgres: 12

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,22 +7,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby: 3.2
+          - ruby: 3.3
             gemfile: gemfiles/activerecord71.gemfile
             postgres: 16
-          - ruby: 3.1
-            gemfile: Gemfile
+          - ruby: 3.3
+            gemfile: gemfiles/activerecord71.gemfile
             postgres: 15
-          - ruby: "3.0"
-            gemfile: gemfiles/activerecord61.gemfile
-            postgres: 12
-          - ruby: 2.7
-            gemfile: gemfiles/activerecord60.gemfile
-            postgres: 10
+          - ruby: 3.3
+            gemfile: gemfiles/activerecord71.gemfile
+            postgres: 14
+          - ruby: 3.3
+            gemfile: gemfiles/activerecord71.gemfile
+            postgres: 13
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.3.4 (unreleased)
+## 3.3.4 (2023-09-05)
 
 - Fixed support for aliases in config file
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.4 (unreleased)
+
+- Fixed support for aliases in config file
+
 ## 3.3.3 (2023-04-18)
 
 - Fixed error with system stats for Azure Database

--- a/lib/pghero.rb
+++ b/lib/pghero.rb
@@ -121,7 +121,7 @@ module PgHero
 
         config_file_exists = File.exist?(path)
 
-        config = YAML.safe_load(ERB.new(File.read(path)).result) if config_file_exists
+        config = YAML.safe_load(ERB.new(File.read(path)).result, aliases: true) if config_file_exists
         config ||= {}
 
         @file_config =

--- a/lib/pghero.rb
+++ b/lib/pghero.rb
@@ -151,7 +151,7 @@ module PgHero
 
       if databases.empty?
         databases["primary"] = {
-          "url" => ENV["PGHERO_DATABASE_URL"] || connection_config(ActiveRecord::Base)
+          "url" => ENV["PGHERO_DATABASE_URL"] || default_connection_config
         }
       end
 
@@ -166,6 +166,11 @@ module PgHero
       {
         "databases" => databases
       }
+    end
+
+    # private
+    def default_connection_config
+      connection_config(ActiveRecord::Base) if ActiveRecord::VERSION::STRING.to_f < 7.1
     end
 
     # ensure we only have one copy of databases

--- a/lib/pghero/version.rb
+++ b/lib/pghero/version.rb
@@ -1,3 +1,3 @@
 module PgHero
-  VERSION = "3.3.3"
+  VERSION = "3.3.4"
 end


### PR DESCRIPTION
Merges the latest upstream [v3.3.4 release](https://github.com/ankane/pghero/releases/tag/v3.3.4) into Buildkite's fork.

https://github.com/ankane/pghero/compare/v3.3.3...v3.3.4

Previous merge:
- #6 

This includes a support for Rails v7.1